### PR TITLE
Fix menu-cta submenu on mobile

### DIFF
--- a/24-code-from-customizer-that.php
+++ b/24-code-from-customizer-that.php
@@ -181,11 +181,6 @@ figure.dp-dfg-image.entry-thumb img {
     position: absolute !important;
     right: 0 !important;
     background-color: #fff !important;
-    display: none !important;
-}
-
-.menu-cta:hover .sub-menu {
-    display: block !important;
 }
 
 /* Mobile Menu adjustments */


### PR DESCRIPTION
## Summary
- remove forced display rules that prevented `menu-cta` submenu from opening on mobile

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684836817d4c83279e9692fbc2208943