### PR TITLE
Add responsive menu cta removal

### DIFF
--- a/58-remove-menu-cta-mobile.php
+++ b/58-remove-menu-cta-mobile.php
@@ -1,0 +1,42 @@
+<?php
+// <Internal Doc Start>
+/*
+*
+* @description:
+* @tags:
+* @group:
+* @name: remove menu-cta class on tablet and mobile
+* @type: PHP
+* @status: published
+* @created_by:
+* @created_at:
+* @updated_at: 2025-02-06 12:00:00
+* @is_valid:
+* @updated_by:
+* @priority: 10
+* @run_at: wp_head
+* @load_as_file:
+* @condition: {"status":"no","run_if":"assertive","items":[[]]}
+*/
+?>
+<?php if (!defined("ABSPATH")) { return;} // <Internal Doc End> ?>
+<?php
+function remove_menu_cta_class_script() {
+    ?>
+    <script type="text/javascript">
+    (function($) {
+        function toggleMenuCTA() {
+            if ($(window).width() <= 980) {
+                $('li.menu-cta').removeClass('menu-cta');
+            } else {
+                $('li.et_pb_menu_page_id-26107970').addClass('menu-cta');
+            }
+        }
+        $(document).ready(toggleMenuCTA);
+        $(window).on('resize', toggleMenuCTA);
+    })(jQuery);
+    </script>
+    <?php
+}
+add_action('wp_footer', 'remove_menu_cta_class_script', 100);
+?>

--- a/index.php
+++ b/index.php
@@ -579,6 +579,32 @@ return array (
       'load_as_file' => '',
       'file_name' => '9-gallery-grid-fix-2x2.php',
     ),
+    '58-remove-menu-cta-mobile.php' =>
+    array (
+      'name' => 'remove menu-cta class on tablet and mobile',
+      'description' => '',
+      'type' => 'PHP',
+      'status' => 'published',
+      'tags' => '',
+      'created_at' => '',
+      'updated_at' => '2025-02-06 12:00:00',
+      'run_at' => 'wp_head',
+      'priority' => 10,
+      'group' => '',
+      'condition' =>
+      array (
+        'status' => 'no',
+        'run_if' => 'assertive',
+        'items' =>
+        array (
+          0 =>
+          array (
+          ),
+        ),
+      ),
+      'load_as_file' => '',
+      'file_name' => '58-remove-menu-cta-mobile.php',
+    ),
   ),
   'draft' => 
   array (
@@ -1572,6 +1598,7 @@ return array (
       11 => '7-read-more-postion-fix.php',
       12 => '8-fix-vc-fluid-grid.php',
       13 => '9-gallery-grid-fix-2x2.php',
+      14 => '58-remove-menu-cta-mobile.php',
     ),
   ),
   'meta' => 


### PR DESCRIPTION
## Summary
- add snippet to remove `menu-cta` class on small screens
- register new snippet in snippet index

## Testing
- `php -l 58-remove-menu-cta-mobile.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68483d479b748327bc5edec041fd08c0